### PR TITLE
Remove jax.ensure_compile_time_eval to fixed tracer leak

### DIFF
--- a/notebooks/Llama3_1_on_Free_Colab_TPU.ipynb
+++ b/notebooks/Llama3_1_on_Free_Colab_TPU.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -47,10 +47,15 @@
      "output_type": "stream",
      "text": [
       "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.3.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
       "\u001b[33mWARNING: Skipping tensorflow as it is not installed.\u001b[0m\u001b[33m\n",
       "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m"
+      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.3.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
      ]
     }
    ],
@@ -61,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "metadata": {
     "id": "CfI9NaUZ_k6U"
    },
@@ -73,19 +78,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {
     "id": "x1zpYQDp8UoV"
    },
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Please enter your HuggingFace token:  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\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "MODEL_NAME = \"meta-llama/Llama-3.2-1B\"\n",
     "HF_TOKEN = input(\"Please enter your HuggingFace token: \")\n",
@@ -101,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -131,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {
     "id": "7DHojRJyxeJ2"
    },
@@ -157,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {
     "id": "tvHYGxp9xySZ"
    },
@@ -191,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {
     "id": "6QybvnqsyKxn"
    },
@@ -228,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -272,7 +269,17 @@
     "id": "W4cFckQ-xoMl",
     "outputId": "729eead0-08fe-4273-e171-1320b8d81d04"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading readme: 100%|██████████| 11.6k/11.6k [00:00<00:00, 21.3MB/s]\n",
+      "Downloading data: 100%|██████████| 44.3M/44.3M [00:00<00:00, 102MB/s] \n",
+      "Generating train split: 51760 examples [00:00, 149637.77 examples/s]\n"
+     ]
+    }
+   ],
    "source": [
     "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, token=HF_TOKEN)\n",
     "\n",
@@ -315,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -364,13 +371,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Creating TPU device mesh with shape (1, 2, 2)...\n",
+      "Creating TPU device mesh with shape (1, 4, 1)...\n",
       "Loading model from HuggingFace...\n"
      ]
     }
    ],
    "source": [
-    "llama_trainer = trainer.Trainer(\n",
+    "trainer = trainer.Trainer(\n",
     "    trainer_config=trainer_config,\n",
     "    train_dataloader=train_dataloader,\n",
     "    val_dataloader=val_dataloader,\n",
@@ -380,7 +387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -394,40 +401,65 @@
      "output_type": "stream",
      "text": [
       "Started epoch 1 of 1...\n",
-      "Step 0 | Train Loss: 0.0000 | Val Loss: 0.0000 | \n"
-     ]
-    },
-    {
-     "ename": "UnexpectedTracerError",
-     "evalue": "Encountered an unexpected tracer. A function transformed by JAX had a side effect, allowing for a reference to an intermediate value with type float32[2048] wrapped in a DynamicJaxprTracer to escape the scope of the transformation.\nJAX transformations require that functions explicitly return their outputs, and disallow saving intermediate values to global state.\nThe function being traced when the value leaked was f at /usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:625 traced for scan.\n------------------------------\nThe leaked intermediate value was created on line /tmp/ipykernel_99/1170177407.py:1 (<module>). \n------------------------------\nWhen the value was created, the final 5 stack frames (most recent last) excluding JAX-internal frames were:\n------------------------------\n/tmp/ipykernel_99/1170177407.py:1 (<module>)\n------------------------------\n\nTo catch the leak earlier, try setting the environment variable JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context manager.\nSee https://jax.readthedocs.io/en/latest/errors.html#jax.errors.UnexpectedTracerError",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mUnexpectedTracerError\u001b[0m                     Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mllama_trainer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtrain\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/trainer.py:307\u001b[0m, in \u001b[0;36mTrainer.train\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    297\u001b[0m batch \u001b[38;5;241m=\u001b[39m host_local_array_to_global_array(\n\u001b[1;32m    298\u001b[0m     batch, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmesh, PS(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbatch\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    299\u001b[0m )\n\u001b[1;32m    300\u001b[0m optimizer_state \u001b[38;5;241m=\u001b[39m jax\u001b[38;5;241m.\u001b[39mdevice_put(\n\u001b[1;32m    301\u001b[0m     optimizer_state, NamedSharding(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmesh, PS())\n\u001b[1;32m    302\u001b[0m )\n\u001b[1;32m    304\u001b[0m (\n\u001b[1;32m    305\u001b[0m     loss,\n\u001b[1;32m    306\u001b[0m     (accuracy, model_params, optimizer_state),\n\u001b[0;32m--> 307\u001b[0m ) \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtraining_step\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    308\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmodel_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    309\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmodel_static\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_static\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    310\u001b[0m \u001b[43m    \u001b[49m\u001b[43moptimizer\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptimizer\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    311\u001b[0m \u001b[43m    \u001b[49m\u001b[43moptimizer_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43moptimizer_state\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    312\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbatch\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    313\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    315\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39meval_interval \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m0\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m (\n\u001b[1;32m    316\u001b[0m     (step \u001b[38;5;241m+\u001b[39m \u001b[38;5;241m1\u001b[39m) \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39meval_interval \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m    317\u001b[0m ):\n\u001b[1;32m    318\u001b[0m     val_loss, val_accuracy \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mevaluate(\n\u001b[1;32m    319\u001b[0m         model_params\u001b[38;5;241m=\u001b[39mmodel_params,\n\u001b[1;32m    320\u001b[0m         model_static\u001b[38;5;241m=\u001b[39mmodel_static,\n\u001b[1;32m    321\u001b[0m         max_eval_steps\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39meval_steps,\n\u001b[1;32m    322\u001b[0m     )\n",
-      "    \u001b[0;31m[... skipping hidden 15 frame]\u001b[0m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/trainer.py:198\u001b[0m, in \u001b[0;36mTrainer.training_step\u001b[0;34m(self, model_params, model_static, optimizer, optimizer_state, batch)\u001b[0m\n\u001b[1;32m    191\u001b[0m \u001b[38;5;129m@functools\u001b[39m\u001b[38;5;241m.\u001b[39mpartial(\n\u001b[1;32m    192\u001b[0m     jax\u001b[38;5;241m.\u001b[39mjit, static_argnames\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mself\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmodel_static\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moptimizer\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    193\u001b[0m )\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtraining_step\u001b[39m(\n\u001b[1;32m    195\u001b[0m     \u001b[38;5;28mself\u001b[39m, model_params, model_static, optimizer, optimizer_state, batch\n\u001b[1;32m    196\u001b[0m ):\n\u001b[1;32m    197\u001b[0m     grad_fn \u001b[38;5;241m=\u001b[39m jax\u001b[38;5;241m.\u001b[39mvalue_and_grad(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mforward, argnums\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m, has_aux\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[0;32m--> 198\u001b[0m     (loss, accuracy), grads \u001b[38;5;241m=\u001b[39m \u001b[43mgrad_fn\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    199\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmodel_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmodel_static\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_static\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbatch\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch\u001b[49m\n\u001b[1;32m    200\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    202\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39muse_lora:\n\u001b[1;32m    203\u001b[0m         \u001b[38;5;66;03m# If using lora, only extract gradients for the lora params.\u001b[39;00m\n\u001b[1;32m    204\u001b[0m         \u001b[38;5;66;03m# Step 1: Partition the gradients into lora and non-lora grads.\u001b[39;00m\n\u001b[1;32m    205\u001b[0m         lora_grads, _ \u001b[38;5;241m=\u001b[39m eqx\u001b[38;5;241m.\u001b[39mpartition(\n\u001b[1;32m    206\u001b[0m             grads,\n\u001b[1;32m    207\u001b[0m             filter_spec\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mis_lora_param_filter_spec,\n\u001b[1;32m    208\u001b[0m             is_leaf\u001b[38;5;241m=\u001b[39meqx\u001b[38;5;241m.\u001b[39mis_array,\n\u001b[1;32m    209\u001b[0m         )\n",
-      "    \u001b[0;31m[... skipping hidden 30 frame]\u001b[0m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/trainer.py:175\u001b[0m, in \u001b[0;36mTrainer.forward\u001b[0;34m(self, model_params, model_static, batch)\u001b[0m\n\u001b[1;32m    172\u001b[0m attention_mask \u001b[38;5;241m=\u001b[39m batch\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mattention_mask\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[1;32m    173\u001b[0m position_ids \u001b[38;5;241m=\u001b[39m batch\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mposition_ids\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[0;32m--> 175\u001b[0m logits \u001b[38;5;241m=\u001b[39m \u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43minput_ids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattention_mask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposition_ids\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    177\u001b[0m \u001b[38;5;66;03m# Shift for next-token prediction\u001b[39;00m\n\u001b[1;32m    178\u001b[0m shifted_logits \u001b[38;5;241m=\u001b[39m logits[\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m, :\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m, :]\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:678\u001b[0m, in \u001b[0;36mLlamaForCausalLM.__call__\u001b[0;34m(self, input_ids, attention_mask, position_ids)\u001b[0m\n\u001b[1;32m    677\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__call__\u001b[39m(\u001b[38;5;28mself\u001b[39m, input_ids, attention_mask\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, position_ids\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[0;32m--> 678\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43minput_ids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattention_mask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposition_ids\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    679\u001b[0m     logits \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlm_head(hidden_states)\n\u001b[1;32m    680\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m logits\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel\u001b[38;5;241m.\u001b[39mcompute_dtype)\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:633\u001b[0m, in \u001b[0;36mLlamaModel.__call__\u001b[0;34m(self, input_ids, attention_mask, position_ids)\u001b[0m\n\u001b[1;32m    628\u001b[0m         hidden_states \u001b[38;5;241m=\u001b[39m eqx\u001b[38;5;241m.\u001b[39mfilter_checkpoint(layer, policy\u001b[38;5;241m=\u001b[39mpolicy)(\n\u001b[1;32m    629\u001b[0m             hidden_states, attention_mask, position_ids\n\u001b[1;32m    630\u001b[0m         )\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcompute_dtype)\n\u001b[1;32m    631\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m hidden_states, \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 633\u001b[0m     hidden_states, _ \u001b[38;5;241m=\u001b[39m \u001b[43mjax\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlax\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mscan\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhidden_states\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdynamic_layers\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    634\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    635\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m layer \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlayers:\n",
-      "    \u001b[0;31m[... skipping hidden 9 frame]\u001b[0m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:628\u001b[0m, in \u001b[0;36mLlamaModel.__call__.<locals>.f\u001b[0;34m(carry, dynamic_layer)\u001b[0m\n\u001b[1;32m    626\u001b[0m hidden_states \u001b[38;5;241m=\u001b[39m carry\n\u001b[1;32m    627\u001b[0m layer \u001b[38;5;241m=\u001b[39m eqx\u001b[38;5;241m.\u001b[39mcombine(dynamic_layer, static_layers)\n\u001b[0;32m--> 628\u001b[0m hidden_states \u001b[38;5;241m=\u001b[39m \u001b[43meqx\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilter_checkpoint\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlayer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpolicy\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mpolicy\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    629\u001b[0m \u001b[43m    \u001b[49m\u001b[43mhidden_states\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattention_mask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposition_ids\u001b[49m\n\u001b[1;32m    630\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcompute_dtype)\n\u001b[1;32m    631\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m hidden_states, \u001b[38;5;28;01mNone\u001b[39;00m\n",
-      "    \u001b[0;31m[... skipping hidden 10 frame]\u001b[0m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:538\u001b[0m, in \u001b[0;36mLlamaDecoderLayer.__call__\u001b[0;34m(self, hidden_states, attention_mask, position_ids)\u001b[0m\n\u001b[1;32m    536\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__call__\u001b[39m(\u001b[38;5;28mself\u001b[39m, hidden_states, attention_mask\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, position_ids\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    537\u001b[0m     residual \u001b[38;5;241m=\u001b[39m hidden_states\n\u001b[0;32m--> 538\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minput_layernorm\u001b[49m\u001b[43m(\u001b[49m\u001b[43mhidden_states\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    539\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mself_attn(\n\u001b[1;32m    540\u001b[0m         hidden_states, position_ids, attention_mask\n\u001b[1;32m    541\u001b[0m     )\n\u001b[1;32m    542\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m residual \u001b[38;5;241m+\u001b[39m hidden_states\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:263\u001b[0m, in \u001b[0;36mLlamaRMSNorm.__call__\u001b[0;34m(self, hidden_states)\u001b[0m\n\u001b[1;32m    261\u001b[0m variance \u001b[38;5;241m=\u001b[39m jnp\u001b[38;5;241m.\u001b[39mmean(hidden_states\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m2\u001b[39m, axis\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m, keepdims\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[1;32m    262\u001b[0m hidden_states \u001b[38;5;241m=\u001b[39m hidden_states \u001b[38;5;241m*\u001b[39m jax\u001b[38;5;241m.\u001b[39mlax\u001b[38;5;241m.\u001b[39mrsqrt(variance \u001b[38;5;241m+\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39meps)\n\u001b[0;32m--> 263\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m (\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mweight\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mastype\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcompute_dtype\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;241m*\u001b[39m hidden_states)\u001b[38;5;241m.\u001b[39mastype(\n\u001b[1;32m    264\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcompute_dtype\n\u001b[1;32m    265\u001b[0m )\n",
-      "    \u001b[0;31m[... skipping hidden 1 frame]\u001b[0m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/jax/_src/numpy/array_methods.py:118\u001b[0m, in \u001b[0;36m_astype\u001b[0;34m(self, dtype, copy, device)\u001b[0m\n\u001b[1;32m    109\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_astype\u001b[39m(\u001b[38;5;28mself\u001b[39m: Array, dtype: DTypeLike \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, copy: \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[1;32m    110\u001b[0m             device: xc\u001b[38;5;241m.\u001b[39mDevice \u001b[38;5;241m|\u001b[39m Sharding \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Array:\n\u001b[1;32m    111\u001b[0m \u001b[38;5;250m  \u001b[39m\u001b[38;5;124;03m\"\"\"Copy the array and cast to a specified dtype.\u001b[39;00m\n\u001b[1;32m    112\u001b[0m \n\u001b[1;32m    113\u001b[0m \u001b[38;5;124;03m  This is implemented via :func:`jax.lax.convert_element_type`, which may\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    116\u001b[0m \u001b[38;5;124;03m  casts are implementation dependent.\u001b[39;00m\n\u001b[1;32m    117\u001b[0m \u001b[38;5;124;03m  \"\"\"\u001b[39;00m\n\u001b[0;32m--> 118\u001b[0m   \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mlax_numpy\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mastype\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcopy\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcopy\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/jax/_src/numpy/lax_numpy.py:5737\u001b[0m, in \u001b[0;36mastype\u001b[0;34m(x, dtype, copy, device)\u001b[0m\n\u001b[1;32m   5735\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m warnings\u001b[38;5;241m.\u001b[39mcatch_warnings():\n\u001b[1;32m   5736\u001b[0m   warnings\u001b[38;5;241m.\u001b[39msimplefilter(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m, ComplexWarning)\n\u001b[0;32m-> 5737\u001b[0m   result \u001b[38;5;241m=\u001b[39m \u001b[43mlax_internal\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_convert_element_type\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   5738\u001b[0m \u001b[43m    \u001b[49m\u001b[43mx_arr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msharding\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_normalize_to_sharding\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   5739\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m _array_copy(result) \u001b[38;5;28;01mif\u001b[39;00m copy \u001b[38;5;28;01melse\u001b[39;00m result\n",
-      "    \u001b[0;31m[... skipping hidden 8 frame]\u001b[0m\n",
-      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/jax/_src/core.py:924\u001b[0m, in \u001b[0;36mcheck_eval_args\u001b[0;34m(args)\u001b[0m\n\u001b[1;32m    922\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args:\n\u001b[1;32m    923\u001b[0m   \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Tracer):\n\u001b[0;32m--> 924\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m escaped_tracer_error(arg)\n",
-      "\u001b[0;31mUnexpectedTracerError\u001b[0m: Encountered an unexpected tracer. A function transformed by JAX had a side effect, allowing for a reference to an intermediate value with type float32[2048] wrapped in a DynamicJaxprTracer to escape the scope of the transformation.\nJAX transformations require that functions explicitly return their outputs, and disallow saving intermediate values to global state.\nThe function being traced when the value leaked was f at /usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:625 traced for scan.\n------------------------------\nThe leaked intermediate value was created on line /tmp/ipykernel_99/1170177407.py:1 (<module>). \n------------------------------\nWhen the value was created, the final 5 stack frames (most recent last) excluding JAX-internal frames were:\n------------------------------\n/tmp/ipykernel_99/1170177407.py:1 (<module>)\n------------------------------\n\nTo catch the leak earlier, try setting the environment variable JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context manager.\nSee https://jax.readthedocs.io/en/latest/errors.html#jax.errors.UnexpectedTracerError"
+      "Step 0 | Train Loss: 0.0000 | Val Loss: 0.0000 | Next Token Prediction Accuracy (train, val): 0.00%, 0.00%\n",
+      "Running eval for 5 steps...\n",
+      "Step 1 | Train Loss: 4.0994 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 26.21%, 26.69%\n",
+      "Step 2 | Train Loss: 3.5532 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 24.19%, 26.69%\n",
+      "Step 3 | Train Loss: 3.0454 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 29.03%, 26.69%\n",
+      "Step 4 | Train Loss: 2.5019 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 48.39%, 26.69%\n",
+      "Step 5 | Train Loss: 2.0899 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 50.81%, 26.69%\n",
+      "Step 6 | Train Loss: 1.5054 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
+      "Step 7 | Train Loss: 1.3784 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
+      "Step 8 | Train Loss: 1.2931 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
+      "Step 9 | Train Loss: 1.1945 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.44%, 26.69%\n",
+      "Step 10 | Train Loss: 1.2426 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.63%, 26.69%\n",
+      "Step 11 | Train Loss: 1.2505 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.63%, 26.69%\n",
+      "Step 12 | Train Loss: 1.2775 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.44%, 26.69%\n",
+      "Step 13 | Train Loss: 1.3155 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 75.81%, 26.69%\n",
+      "Step 14 | Train Loss: 1.1394 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
+      "Step 15 | Train Loss: 1.1252 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.84%, 26.69%\n",
+      "Step 16 | Train Loss: 1.0552 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
+      "Step 17 | Train Loss: 1.1231 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.44%, 26.69%\n",
+      "Step 18 | Train Loss: 1.2227 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
+      "Step 19 | Train Loss: 1.1082 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.84%, 26.69%\n",
+      "Step 20 | Train Loss: 1.0983 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.03%, 26.69%\n",
+      "Step 21 | Train Loss: 0.9793 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.84%, 26.69%\n",
+      "Step 22 | Train Loss: 1.1741 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
+      "Step 23 | Train Loss: 1.0463 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
+      "Step 24 | Train Loss: 0.9950 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
+      "Step 25 | Train Loss: 0.9752 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.26%, 26.69%\n",
+      "Step 26 | Train Loss: 1.0747 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 76.61%, 26.69%\n",
+      "Step 27 | Train Loss: 1.1273 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
+      "Step 28 | Train Loss: 1.0553 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 76.61%, 26.69%\n",
+      "Step 29 | Train Loss: 0.8821 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
+      "Step 30 | Train Loss: 0.9886 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
+      "Step 31 | Train Loss: 0.8033 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.27%, 26.69%\n",
+      "Step 32 | Train Loss: 0.8578 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 83.87%, 26.69%\n",
+      "Step 33 | Train Loss: 0.8571 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.85%, 26.69%\n",
+      "Step 34 | Train Loss: 0.8510 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
+      "Step 35 | Train Loss: 0.8775 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
+      "Step 36 | Train Loss: 0.8155 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 83.87%, 26.69%\n",
+      "Step 37 | Train Loss: 0.8432 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.26%, 26.69%\n",
+      "Step 38 | Train Loss: 0.8596 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
+      "Step 39 | Train Loss: 0.9499 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.85%, 26.69%\n",
+      "Step 40 | Train Loss: 0.7451 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.68%, 26.69%\n",
+      "Step 41 | Train Loss: 0.7369 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.27%, 26.69%\n",
+      "Step 42 | Train Loss: 0.8250 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
+      "Step 43 | Train Loss: 0.8935 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.66%, 26.69%\n",
+      "Step 44 | Train Loss: 0.7708 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.27%, 26.69%\n",
+      "Step 45 | Train Loss: 0.9521 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
+      "Step 46 | Train Loss: 0.8572 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.85%, 26.69%\n",
+      "Step 47 | Train Loss: 0.9187 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.26%, 26.69%\n",
+      "Step 48 | Train Loss: 0.6980 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 85.48%, 26.69%\n",
+      "Step 49 | Train Loss: 0.8168 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
+      "Running eval for 5 steps...\n",
+      "Training completed!\n",
+      "Final checkpoint saved at: /checkpoints\n"
      ]
     }
    ],
    "source": [
-    "llama_trainer.train()"
+    "trainer.train()"
    ]
   },
   {
@@ -441,22 +473,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "id": "D_7oZYSi22UE"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model and tokenizer saved to /finetuned_export\n",
+      "Hugging Face model saved at: /finetuned_export\n"
+     ]
+    }
+   ],
    "source": [
-    "llama_trainer.export(export_dir=EXPORT_DIR)"
+    "trainer.export(export_dir=EXPORT_DIR)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
     "id": "N4FdH8MF25Y3"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tokenizer.json: 100%|██████████| 9.09M/9.09M [00:00<00:00, 13.0MB/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model uploaded to Hugging Face Hub at https://huggingface.co/felarof01/test-llama3-alpaca-from-colab\n"
+     ]
+    }
+   ],
    "source": [
     "utils.upload_dir_to_hf(\n",
     "    dir_path=EXPORT_DIR,\n",
@@ -477,18 +533,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.16"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/notebooks/Llama3_1_on_Free_Colab_TPU.ipynb
+++ b/notebooks/Llama3_1_on_Free_Colab_TPU.ipynb
@@ -47,15 +47,10 @@
      "output_type": "stream",
      "text": [
       "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.3.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
       "\u001b[33mWARNING: Skipping tensorflow as it is not installed.\u001b[0m\u001b[33m\n",
       "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
-      "\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m24.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.3.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n"
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\n",
+      "\u001b[0m"
      ]
     }
    ],
@@ -78,11 +73,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "id": "x1zpYQDp8UoV"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Please enter your HuggingFace token:  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\n"
+     ]
+    }
+   ],
    "source": [
     "MODEL_NAME = \"meta-llama/Llama-3.2-1B\"\n",
     "HF_TOKEN = input(\"Please enter your HuggingFace token: \")\n",
@@ -98,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -106,7 +109,16 @@
     "id": "l0X3Dqio7eQl",
     "outputId": "3cf05844-f549-404d-db3e-f2c80021c0d8"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
    "source": [
     "from felafax.trainer_engine import setup\n",
     "setup.setup_environment(base_dir=TRAINER_DIR)\n",
@@ -128,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {
     "id": "7DHojRJyxeJ2"
    },
@@ -154,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {
     "id": "tvHYGxp9xySZ"
    },
@@ -188,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "metadata": {
     "id": "6QybvnqsyKxn"
    },
@@ -225,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -274,9 +286,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Downloading readme: 100%|██████████| 11.6k/11.6k [00:00<00:00, 21.3MB/s]\n",
-      "Downloading data: 100%|██████████| 44.3M/44.3M [00:00<00:00, 102MB/s] \n",
-      "Generating train split: 51760 examples [00:00, 149637.77 examples/s]\n"
+      "Downloading readme: 100%|██████████| 11.6k/11.6k [00:00<00:00, 24.6MB/s]\n",
+      "Downloading data: 100%|██████████| 44.3M/44.3M [00:00<00:00, 73.0MB/s]\n",
+      "Generating train split: 51760 examples [00:00, 104327.90 examples/s]\n"
      ]
     }
    ],
@@ -322,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -371,13 +383,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Creating TPU device mesh with shape (1, 4, 1)...\n",
+      "Creating TPU device mesh with shape (1, 2, 2)...\n",
       "Loading model from HuggingFace...\n"
      ]
     }
    ],
    "source": [
-    "trainer = trainer.Trainer(\n",
+    "llama_trainer = trainer.Trainer(\n",
     "    trainer_config=trainer_config,\n",
     "    train_dataloader=train_dataloader,\n",
     "    val_dataloader=val_dataloader,\n",
@@ -387,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -395,71 +407,9 @@
     "id": "C6l2zw0Rzyt_",
     "outputId": "d23c8564-2759-427c-b65c-11f2e86a1b4e"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Started epoch 1 of 1...\n",
-      "Step 0 | Train Loss: 0.0000 | Val Loss: 0.0000 | Next Token Prediction Accuracy (train, val): 0.00%, 0.00%\n",
-      "Running eval for 5 steps...\n",
-      "Step 1 | Train Loss: 4.0994 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 26.21%, 26.69%\n",
-      "Step 2 | Train Loss: 3.5532 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 24.19%, 26.69%\n",
-      "Step 3 | Train Loss: 3.0454 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 29.03%, 26.69%\n",
-      "Step 4 | Train Loss: 2.5019 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 48.39%, 26.69%\n",
-      "Step 5 | Train Loss: 2.0899 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 50.81%, 26.69%\n",
-      "Step 6 | Train Loss: 1.5054 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
-      "Step 7 | Train Loss: 1.3784 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
-      "Step 8 | Train Loss: 1.2931 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
-      "Step 9 | Train Loss: 1.1945 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.44%, 26.69%\n",
-      "Step 10 | Train Loss: 1.2426 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.63%, 26.69%\n",
-      "Step 11 | Train Loss: 1.2505 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.63%, 26.69%\n",
-      "Step 12 | Train Loss: 1.2775 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.44%, 26.69%\n",
-      "Step 13 | Train Loss: 1.3155 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 75.81%, 26.69%\n",
-      "Step 14 | Train Loss: 1.1394 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
-      "Step 15 | Train Loss: 1.1252 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.84%, 26.69%\n",
-      "Step 16 | Train Loss: 1.0552 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
-      "Step 17 | Train Loss: 1.1231 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.44%, 26.69%\n",
-      "Step 18 | Train Loss: 1.2227 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
-      "Step 19 | Train Loss: 1.1082 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.84%, 26.69%\n",
-      "Step 20 | Train Loss: 1.0983 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.03%, 26.69%\n",
-      "Step 21 | Train Loss: 0.9793 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 79.84%, 26.69%\n",
-      "Step 22 | Train Loss: 1.1741 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
-      "Step 23 | Train Loss: 1.0463 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
-      "Step 24 | Train Loss: 0.9950 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
-      "Step 25 | Train Loss: 0.9752 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.26%, 26.69%\n",
-      "Step 26 | Train Loss: 1.0747 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 76.61%, 26.69%\n",
-      "Step 27 | Train Loss: 1.1273 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
-      "Step 28 | Train Loss: 1.0553 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 76.61%, 26.69%\n",
-      "Step 29 | Train Loss: 0.8821 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 78.23%, 26.69%\n",
-      "Step 30 | Train Loss: 0.9886 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 77.42%, 26.69%\n",
-      "Step 31 | Train Loss: 0.8033 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.27%, 26.69%\n",
-      "Step 32 | Train Loss: 0.8578 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 83.87%, 26.69%\n",
-      "Step 33 | Train Loss: 0.8571 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.85%, 26.69%\n",
-      "Step 34 | Train Loss: 0.8510 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
-      "Step 35 | Train Loss: 0.8775 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
-      "Step 36 | Train Loss: 0.8155 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 83.87%, 26.69%\n",
-      "Step 37 | Train Loss: 0.8432 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.26%, 26.69%\n",
-      "Step 38 | Train Loss: 0.8596 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.05%, 26.69%\n",
-      "Step 39 | Train Loss: 0.9499 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.85%, 26.69%\n",
-      "Step 40 | Train Loss: 0.7451 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.68%, 26.69%\n",
-      "Step 41 | Train Loss: 0.7369 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.27%, 26.69%\n",
-      "Step 42 | Train Loss: 0.8250 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
-      "Step 43 | Train Loss: 0.8935 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.66%, 26.69%\n",
-      "Step 44 | Train Loss: 0.7708 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 84.27%, 26.69%\n",
-      "Step 45 | Train Loss: 0.9521 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
-      "Step 46 | Train Loss: 0.8572 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 81.85%, 26.69%\n",
-      "Step 47 | Train Loss: 0.9187 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 82.26%, 26.69%\n",
-      "Step 48 | Train Loss: 0.6980 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 85.48%, 26.69%\n",
-      "Step 49 | Train Loss: 0.8168 | Val Loss: 3.6469 | Next Token Prediction Accuracy (train, val): 80.65%, 26.69%\n",
-      "Running eval for 5 steps...\n",
-      "Training completed!\n",
-      "Final checkpoint saved at: /checkpoints\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "trainer.train()"
+    "llama_trainer.train()"
    ]
   },
   {
@@ -473,46 +423,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "id": "D_7oZYSi22UE"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model and tokenizer saved to /finetuned_export\n",
-      "Hugging Face model saved at: /finetuned_export\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "trainer.export(export_dir=EXPORT_DIR)"
+    "llama_trainer.export(export_dir=EXPORT_DIR)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "id": "N4FdH8MF25Y3"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "tokenizer.json: 100%|██████████| 9.09M/9.09M [00:00<00:00, 13.0MB/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model uploaded to Hugging Face Hub at https://huggingface.co/felarof01/test-llama3-alpaca-from-colab\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "utils.upload_dir_to_hf(\n",
     "    dir_path=EXPORT_DIR,\n",
@@ -533,6 +459,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/notebooks/Llama3_1_on_Free_Colab_TPU.ipynb
+++ b/notebooks/Llama3_1_on_Free_Colab_TPU.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "metadata": {
     "id": "CfI9NaUZ_k6U"
    },
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "metadata": {
     "id": "x1zpYQDp8UoV"
    },
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -109,16 +109,7 @@
     "id": "l0X3Dqio7eQl",
     "outputId": "3cf05844-f549-404d-db3e-f2c80021c0d8"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from felafax.trainer_engine import setup\n",
     "setup.setup_environment(base_dir=TRAINER_DIR)\n",
@@ -140,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "metadata": {
     "id": "7DHojRJyxeJ2"
    },
@@ -166,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {
     "id": "tvHYGxp9xySZ"
    },
@@ -200,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {
     "id": "6QybvnqsyKxn"
    },
@@ -237,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -281,17 +272,7 @@
     "id": "W4cFckQ-xoMl",
     "outputId": "729eead0-08fe-4273-e171-1320b8d81d04"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Downloading readme: 100%|██████████| 11.6k/11.6k [00:00<00:00, 24.6MB/s]\n",
-      "Downloading data: 100%|██████████| 44.3M/44.3M [00:00<00:00, 73.0MB/s]\n",
-      "Generating train split: 51760 examples [00:00, 104327.90 examples/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, token=HF_TOKEN)\n",
     "\n",
@@ -334,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 19,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -399,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -407,7 +388,44 @@
     "id": "C6l2zw0Rzyt_",
     "outputId": "d23c8564-2759-427c-b65c-11f2e86a1b4e"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Started epoch 1 of 1...\n",
+      "Step 0 | Train Loss: 0.0000 | Val Loss: 0.0000 | \n"
+     ]
+    },
+    {
+     "ename": "UnexpectedTracerError",
+     "evalue": "Encountered an unexpected tracer. A function transformed by JAX had a side effect, allowing for a reference to an intermediate value with type float32[2048] wrapped in a DynamicJaxprTracer to escape the scope of the transformation.\nJAX transformations require that functions explicitly return their outputs, and disallow saving intermediate values to global state.\nThe function being traced when the value leaked was f at /usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:625 traced for scan.\n------------------------------\nThe leaked intermediate value was created on line /tmp/ipykernel_99/1170177407.py:1 (<module>). \n------------------------------\nWhen the value was created, the final 5 stack frames (most recent last) excluding JAX-internal frames were:\n------------------------------\n/tmp/ipykernel_99/1170177407.py:1 (<module>)\n------------------------------\n\nTo catch the leak earlier, try setting the environment variable JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context manager.\nSee https://jax.readthedocs.io/en/latest/errors.html#jax.errors.UnexpectedTracerError",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mUnexpectedTracerError\u001b[0m                     Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mllama_trainer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtrain\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/trainer.py:307\u001b[0m, in \u001b[0;36mTrainer.train\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    297\u001b[0m batch \u001b[38;5;241m=\u001b[39m host_local_array_to_global_array(\n\u001b[1;32m    298\u001b[0m     batch, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmesh, PS(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbatch\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    299\u001b[0m )\n\u001b[1;32m    300\u001b[0m optimizer_state \u001b[38;5;241m=\u001b[39m jax\u001b[38;5;241m.\u001b[39mdevice_put(\n\u001b[1;32m    301\u001b[0m     optimizer_state, NamedSharding(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmesh, PS())\n\u001b[1;32m    302\u001b[0m )\n\u001b[1;32m    304\u001b[0m (\n\u001b[1;32m    305\u001b[0m     loss,\n\u001b[1;32m    306\u001b[0m     (accuracy, model_params, optimizer_state),\n\u001b[0;32m--> 307\u001b[0m ) \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtraining_step\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    308\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmodel_params\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_params\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    309\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmodel_static\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_static\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    310\u001b[0m \u001b[43m    \u001b[49m\u001b[43moptimizer\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptimizer\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    311\u001b[0m \u001b[43m    \u001b[49m\u001b[43moptimizer_state\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43moptimizer_state\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    312\u001b[0m \u001b[43m    \u001b[49m\u001b[43mbatch\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    313\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    315\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39meval_interval \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m0\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m (\n\u001b[1;32m    316\u001b[0m     (step \u001b[38;5;241m+\u001b[39m \u001b[38;5;241m1\u001b[39m) \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39meval_interval \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m    317\u001b[0m ):\n\u001b[1;32m    318\u001b[0m     val_loss, val_accuracy \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mevaluate(\n\u001b[1;32m    319\u001b[0m         model_params\u001b[38;5;241m=\u001b[39mmodel_params,\n\u001b[1;32m    320\u001b[0m         model_static\u001b[38;5;241m=\u001b[39mmodel_static,\n\u001b[1;32m    321\u001b[0m         max_eval_steps\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39meval_steps,\n\u001b[1;32m    322\u001b[0m     )\n",
+      "    \u001b[0;31m[... skipping hidden 15 frame]\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/trainer.py:198\u001b[0m, in \u001b[0;36mTrainer.training_step\u001b[0;34m(self, model_params, model_static, optimizer, optimizer_state, batch)\u001b[0m\n\u001b[1;32m    191\u001b[0m \u001b[38;5;129m@functools\u001b[39m\u001b[38;5;241m.\u001b[39mpartial(\n\u001b[1;32m    192\u001b[0m     jax\u001b[38;5;241m.\u001b[39mjit, static_argnames\u001b[38;5;241m=\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mself\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmodel_static\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124moptimizer\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    193\u001b[0m )\n\u001b[1;32m    194\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mtraining_step\u001b[39m(\n\u001b[1;32m    195\u001b[0m     \u001b[38;5;28mself\u001b[39m, model_params, model_static, optimizer, optimizer_state, batch\n\u001b[1;32m    196\u001b[0m ):\n\u001b[1;32m    197\u001b[0m     grad_fn \u001b[38;5;241m=\u001b[39m jax\u001b[38;5;241m.\u001b[39mvalue_and_grad(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mforward, argnums\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m, has_aux\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[0;32m--> 198\u001b[0m     (loss, accuracy), grads \u001b[38;5;241m=\u001b[39m \u001b[43mgrad_fn\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    199\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmodel_params\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmodel_static\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_static\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbatch\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mbatch\u001b[49m\n\u001b[1;32m    200\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    202\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtrainer_config\u001b[38;5;241m.\u001b[39muse_lora:\n\u001b[1;32m    203\u001b[0m         \u001b[38;5;66;03m# If using lora, only extract gradients for the lora params.\u001b[39;00m\n\u001b[1;32m    204\u001b[0m         \u001b[38;5;66;03m# Step 1: Partition the gradients into lora and non-lora grads.\u001b[39;00m\n\u001b[1;32m    205\u001b[0m         lora_grads, _ \u001b[38;5;241m=\u001b[39m eqx\u001b[38;5;241m.\u001b[39mpartition(\n\u001b[1;32m    206\u001b[0m             grads,\n\u001b[1;32m    207\u001b[0m             filter_spec\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mis_lora_param_filter_spec,\n\u001b[1;32m    208\u001b[0m             is_leaf\u001b[38;5;241m=\u001b[39meqx\u001b[38;5;241m.\u001b[39mis_array,\n\u001b[1;32m    209\u001b[0m         )\n",
+      "    \u001b[0;31m[... skipping hidden 30 frame]\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/trainer.py:175\u001b[0m, in \u001b[0;36mTrainer.forward\u001b[0;34m(self, model_params, model_static, batch)\u001b[0m\n\u001b[1;32m    172\u001b[0m attention_mask \u001b[38;5;241m=\u001b[39m batch\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mattention_mask\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[1;32m    173\u001b[0m position_ids \u001b[38;5;241m=\u001b[39m batch\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mposition_ids\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[0;32m--> 175\u001b[0m logits \u001b[38;5;241m=\u001b[39m \u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43minput_ids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattention_mask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposition_ids\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    177\u001b[0m \u001b[38;5;66;03m# Shift for next-token prediction\u001b[39;00m\n\u001b[1;32m    178\u001b[0m shifted_logits \u001b[38;5;241m=\u001b[39m logits[\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m, :\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m, :]\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:678\u001b[0m, in \u001b[0;36mLlamaForCausalLM.__call__\u001b[0;34m(self, input_ids, attention_mask, position_ids)\u001b[0m\n\u001b[1;32m    677\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__call__\u001b[39m(\u001b[38;5;28mself\u001b[39m, input_ids, attention_mask\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, position_ids\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[0;32m--> 678\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\u001b[43minput_ids\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattention_mask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposition_ids\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    679\u001b[0m     logits \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlm_head(hidden_states)\n\u001b[1;32m    680\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m logits\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel\u001b[38;5;241m.\u001b[39mcompute_dtype)\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:633\u001b[0m, in \u001b[0;36mLlamaModel.__call__\u001b[0;34m(self, input_ids, attention_mask, position_ids)\u001b[0m\n\u001b[1;32m    628\u001b[0m         hidden_states \u001b[38;5;241m=\u001b[39m eqx\u001b[38;5;241m.\u001b[39mfilter_checkpoint(layer, policy\u001b[38;5;241m=\u001b[39mpolicy)(\n\u001b[1;32m    629\u001b[0m             hidden_states, attention_mask, position_ids\n\u001b[1;32m    630\u001b[0m         )\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcompute_dtype)\n\u001b[1;32m    631\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m hidden_states, \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m--> 633\u001b[0m     hidden_states, _ \u001b[38;5;241m=\u001b[39m \u001b[43mjax\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlax\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mscan\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhidden_states\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdynamic_layers\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    634\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    635\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m layer \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlayers:\n",
+      "    \u001b[0;31m[... skipping hidden 9 frame]\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:628\u001b[0m, in \u001b[0;36mLlamaModel.__call__.<locals>.f\u001b[0;34m(carry, dynamic_layer)\u001b[0m\n\u001b[1;32m    626\u001b[0m hidden_states \u001b[38;5;241m=\u001b[39m carry\n\u001b[1;32m    627\u001b[0m layer \u001b[38;5;241m=\u001b[39m eqx\u001b[38;5;241m.\u001b[39mcombine(dynamic_layer, static_layers)\n\u001b[0;32m--> 628\u001b[0m hidden_states \u001b[38;5;241m=\u001b[39m \u001b[43meqx\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfilter_checkpoint\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlayer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpolicy\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mpolicy\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    629\u001b[0m \u001b[43m    \u001b[49m\u001b[43mhidden_states\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattention_mask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mposition_ids\u001b[49m\n\u001b[1;32m    630\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcompute_dtype)\n\u001b[1;32m    631\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m hidden_states, \u001b[38;5;28;01mNone\u001b[39;00m\n",
+      "    \u001b[0;31m[... skipping hidden 10 frame]\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:538\u001b[0m, in \u001b[0;36mLlamaDecoderLayer.__call__\u001b[0;34m(self, hidden_states, attention_mask, position_ids)\u001b[0m\n\u001b[1;32m    536\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__call__\u001b[39m(\u001b[38;5;28mself\u001b[39m, hidden_states, attention_mask\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, position_ids\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    537\u001b[0m     residual \u001b[38;5;241m=\u001b[39m hidden_states\n\u001b[0;32m--> 538\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43minput_layernorm\u001b[49m\u001b[43m(\u001b[49m\u001b[43mhidden_states\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    539\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mself_attn(\n\u001b[1;32m    540\u001b[0m         hidden_states, position_ids, attention_mask\n\u001b[1;32m    541\u001b[0m     )\n\u001b[1;32m    542\u001b[0m     hidden_states \u001b[38;5;241m=\u001b[39m residual \u001b[38;5;241m+\u001b[39m hidden_states\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:263\u001b[0m, in \u001b[0;36mLlamaRMSNorm.__call__\u001b[0;34m(self, hidden_states)\u001b[0m\n\u001b[1;32m    261\u001b[0m variance \u001b[38;5;241m=\u001b[39m jnp\u001b[38;5;241m.\u001b[39mmean(hidden_states\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m2\u001b[39m, axis\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m1\u001b[39m, keepdims\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[1;32m    262\u001b[0m hidden_states \u001b[38;5;241m=\u001b[39m hidden_states \u001b[38;5;241m*\u001b[39m jax\u001b[38;5;241m.\u001b[39mlax\u001b[38;5;241m.\u001b[39mrsqrt(variance \u001b[38;5;241m+\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39meps)\n\u001b[0;32m--> 263\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m (\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mweight\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mastype\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcompute_dtype\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;241m*\u001b[39m hidden_states)\u001b[38;5;241m.\u001b[39mastype(\n\u001b[1;32m    264\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcompute_dtype\n\u001b[1;32m    265\u001b[0m )\n",
+      "    \u001b[0;31m[... skipping hidden 1 frame]\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/jax/_src/numpy/array_methods.py:118\u001b[0m, in \u001b[0;36m_astype\u001b[0;34m(self, dtype, copy, device)\u001b[0m\n\u001b[1;32m    109\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_astype\u001b[39m(\u001b[38;5;28mself\u001b[39m: Array, dtype: DTypeLike \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m, copy: \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[1;32m    110\u001b[0m             device: xc\u001b[38;5;241m.\u001b[39mDevice \u001b[38;5;241m|\u001b[39m Sharding \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Array:\n\u001b[1;32m    111\u001b[0m \u001b[38;5;250m  \u001b[39m\u001b[38;5;124;03m\"\"\"Copy the array and cast to a specified dtype.\u001b[39;00m\n\u001b[1;32m    112\u001b[0m \n\u001b[1;32m    113\u001b[0m \u001b[38;5;124;03m  This is implemented via :func:`jax.lax.convert_element_type`, which may\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    116\u001b[0m \u001b[38;5;124;03m  casts are implementation dependent.\u001b[39;00m\n\u001b[1;32m    117\u001b[0m \u001b[38;5;124;03m  \"\"\"\u001b[39;00m\n\u001b[0;32m--> 118\u001b[0m   \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mlax_numpy\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mastype\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcopy\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcopy\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/jax/_src/numpy/lax_numpy.py:5737\u001b[0m, in \u001b[0;36mastype\u001b[0;34m(x, dtype, copy, device)\u001b[0m\n\u001b[1;32m   5735\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m warnings\u001b[38;5;241m.\u001b[39mcatch_warnings():\n\u001b[1;32m   5736\u001b[0m   warnings\u001b[38;5;241m.\u001b[39msimplefilter(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m, ComplexWarning)\n\u001b[0;32m-> 5737\u001b[0m   result \u001b[38;5;241m=\u001b[39m \u001b[43mlax_internal\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_convert_element_type\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   5738\u001b[0m \u001b[43m    \u001b[49m\u001b[43mx_arr\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43msharding\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m_normalize_to_sharding\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   5739\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m _array_copy(result) \u001b[38;5;28;01mif\u001b[39;00m copy \u001b[38;5;28;01melse\u001b[39;00m result\n",
+      "    \u001b[0;31m[... skipping hidden 8 frame]\u001b[0m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.10/site-packages/jax/_src/core.py:924\u001b[0m, in \u001b[0;36mcheck_eval_args\u001b[0;34m(args)\u001b[0m\n\u001b[1;32m    922\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args:\n\u001b[1;32m    923\u001b[0m   \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Tracer):\n\u001b[0;32m--> 924\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m escaped_tracer_error(arg)\n",
+      "\u001b[0;31mUnexpectedTracerError\u001b[0m: Encountered an unexpected tracer. A function transformed by JAX had a side effect, allowing for a reference to an intermediate value with type float32[2048] wrapped in a DynamicJaxprTracer to escape the scope of the transformation.\nJAX transformations require that functions explicitly return their outputs, and disallow saving intermediate values to global state.\nThe function being traced when the value leaked was f at /usr/local/lib/python3.10/site-packages/felafax/trainer_engine/models/llama3/jax/model.py:625 traced for scan.\n------------------------------\nThe leaked intermediate value was created on line /tmp/ipykernel_99/1170177407.py:1 (<module>). \n------------------------------\nWhen the value was created, the final 5 stack frames (most recent last) excluding JAX-internal frames were:\n------------------------------\n/tmp/ipykernel_99/1170177407.py:1 (<module>)\n------------------------------\n\nTo catch the leak earlier, try setting the environment variable JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context manager.\nSee https://jax.readthedocs.io/en/latest/errors.html#jax.errors.UnexpectedTracerError"
+     ]
+    }
+   ],
    "source": [
     "llama_trainer.train()"
    ]

--- a/src/felafax/trainer_engine/trainer.py
+++ b/src/felafax/trainer_engine/trainer.py
@@ -164,7 +164,6 @@ class Trainer:
         )
         self.opt_state = self.optimizer.init(optimizer_params)
 
-    @functools.partial(jax.jit, static_argnames=("self", "model_static"))
     def forward(self, model_params, model_static, batch):
         model = eqx.combine(model_params, model_static)
         input_ids = batch["input_ids"]


### PR DESCRIPTION
Remove jax.ensure_compile_time_eval block to fix tracer leak
.astype() calls within ensure_compile_time_eval and eqx.filter_vmap caused dynamic tracers to escape. 
